### PR TITLE
Added missing parameters for initContainers

### DIFF
--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -5,7 +5,7 @@ description: A Helm chart for creating Kubernetes CronJobs
 icon: file://icon.svg
 
 # Chart Version
-version: 0.1.0
+version: 0.1.1
 
 appVersion: "1.0.0"
 

--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -22,7 +22,7 @@ spec:
           initContainers:
           {{- range $name, $config := .Values.initContainers }}
             - name: {{ $name }}
-              {{- include "common.containerConfig" . | nindent 14 }}
+              {{- include "common.containerConfig" ( dict "root" $ "container" $config ) | nindent 14 }}
               {{- with $config.command }}
               command: {{ $config.command | toYaml | nindent 16 }}
               {{- end }}


### PR DESCRIPTION
## Description
initContainers for CronJobs are not working with this version of the Helm Chart.

## Solution
Pass the needed parameters to the template to correctly generate the initContainer.

## Testing
Since this repository was locked, the change was made in the base repo used to build this one. It's being used right now and should be replaced with the official chart.

## Additional notes
N/A